### PR TITLE
Update Makefile to only build for linux/amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ out/enclaveos.tar: out \
 	docker build \
 		--tag $(REGISTRY)/enclaveos \
 		--progress=plain \
+		--platform linux/amd64 \
 		--output type=local,rewrite-timestamp=true,dest=out\
 		-f Containerfile \
 		.


### PR DESCRIPTION
We only intend to build the eif for amd64/ EC2 instance and not on arm64, This makes it so that you can also build the eif on macOS without causing platform compatibility errors