### PR TITLE
chore: add readme for move package

### DIFF
--- a/move/enclave/README.md
+++ b/move/enclave/README.md
@@ -1,0 +1,5 @@
+# Nautilus Package
+
+Nautilus is a framework for **secure and verifiable off-chain computation on Sui**. For full product details, see the [Nautilus documentation](https://docs.sui.io/concepts/cryptography/nautilus).
+
+The Nautilus package includes a pattern to manage enclaves onchain with creating and updating enclave configs, registering enclaves and verifying signature with it. 


### PR DESCRIPTION
this readme is used to populate MVR info page, e.g. https://www.moveregistry.com/package/@mysten/kiosk

