### PR TITLE
docs: fix Nautilus documentation link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nautilus: Verifiable offchain computation on Sui
 
-Nautilus is a framework for **secure and verifiable off-chain computation on Sui**. For full product details, see the [Nautilus documentation](https://docs.sui.io/concepts/cryptography/nautilus).
+Nautilus is a framework for **secure and verifiable off-chain computation on Sui**. For full product details, see the [Nautilus documentation](https://docs.sui.io/guides/developer/nautilus/).
 
 This repository includes a reproducible build template for AWS Nitro Enclaves, along with patterns and examples for hybrid application development. For a complete end-to-end example, see the [Nautilus Twitter repository](https://github.com/MystenLabs/nautilus-twitter).
 
@@ -8,4 +8,5 @@ This repository includes a reproducible build template for AWS Nitro Enclaves, a
 > The reproducible build template is intended as a starting point for building your own enclave. It is not feature complete, has not undergone a security audit, and is offered as a modification-friendly reference licensed under the Apache 2.0 license. THE TEMPLATE AND ITS RELATED DOCUMENTATION ARE PROVIDED AS IS WITHOUT WARRANTY OF ANY KIND FOR EVALUATION PURPOSES ONLY. You can adapt and extend it to fit your specific use case.
 
 ## Contact Us
+
 For questions about Nautilus, use case discussions, or integration support, contact the Nautilus team on [Sui Discord](https://discord.com/channels/916379725201563759/1361500579603546223).


### PR DESCRIPTION
Update docs URL from concepts/cryptography to guides/developer path