### PR TITLE
Don't gate the port-3000 forwarder on the secrets exchange

### DIFF
--- a/expose_enclave.sh
+++ b/expose_enclave.sh
@@ -8,10 +8,17 @@ ENCLAVE_ID=$(nitro-cli describe-enclaves | jq -r ".[0].EnclaveID")
 ENCLAVE_CID=$(nitro-cli describe-enclaves | jq -r ".[0].EnclaveCID")
 
 sleep 5
+# Forward host port 3000 to the enclave. This only opens a local listener -- it
+# connects to the enclave lazily, per incoming connection -- so it is started
+# before the secrets exchange below rather than after it, and cannot be left
+# unstarted if that exchange does not complete.
+socat TCP4-LISTEN:3000,reuseaddr,fork VSOCK-CONNECT:$ENCLAVE_CID:3000 &
+
 # Secrets-block
 # This section will be populated by configure_enclave.sh based on secret configuration
 
-cat secrets.json | socat - VSOCK-CONNECT:$ENCLAVE_CID:7777
-socat TCP4-LISTEN:3000,reuseaddr,fork VSOCK-CONNECT:$ENCLAVE_CID:3000 &
+# Hand the enclave its secrets. -T bounds the exchange: without it this socat has
+# been observed not to return, leaving the script hung.
+cat secrets.json | socat -T 5 - VSOCK-CONNECT:$ENCLAVE_CID:7777
 
 # Additional port configurations will be added here by configure_enclave.sh if needed


### PR DESCRIPTION
## What

`expose_enclave.sh` hands the enclave its secrets and *then* starts the host→enclave forwarder for port 3000:

```sh
cat secrets.json | socat - VSOCK-CONNECT:$ENCLAVE_CID:7777
socat TCP4-LISTEN:3000,reuseaddr,fork VSOCK-CONNECT:$ENCLAVE_CID:3000 &
```

I've seen the first line not return. When that happens the script hangs there, the second line never runs, and the enclave is unreachable on port 3000 — even though it booted, took its secrets, and is serving. It presents as a broken enclave rather than a stuck script, which is what cost me the time.

This PR stops either line from being able to strand the other:

- start the forwarder first. It only opens a local listener, and with `fork` it connects to the enclave lazily per incoming connection, so it doesn't need the enclave to be up yet;
- bound the secrets send with `socat -T 5`, so the script terminates either way.

## Caveat — worth a second opinion

I have not pinned the root cause, and I hit it with my own app and an empty `secrets.json` (the no-secret path `configure_enclave.sh` generates), not with `weather-example`. The enclave side clearly got past its `socat - VSOCK-LISTEN:7777` — it went on to serve `/get_attestation` — so the secrets were delivered and it's the host-side `socat` that stayed up. My guess is a half-close that doesn't propagate the way socat expects over `AF_VSOCK`, but I haven't proven it.

That uncertainty is why the change is shaped as robustness rather than a targeted fix. If someone can reproduce it (or fail to) on a stock example, I'd like to know.

## Compatibility with `configure_enclave.sh`

`configure_enclave.sh` rewrites this file with `sed`, anchored on the `# Secrets-block` comment and on the port-3000 `socat` line. Both are preserved byte-for-byte. I ran both generated rewrites (the seal path and the no-secret path) against the new file: `echo '{}' > secrets.json` still lands before `secrets.json` is read, and the port-3001 line still lands after the port-3000 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
