### PR TITLE
Add a test-only Enclave constructor, and test verify_signature

### DIFF
--- a/move/enclave/sources/enclave.move
+++ b/move/enclave/sources/enclave.move
@@ -185,6 +185,19 @@ public fun destroy<T>(enclave: Enclave<T>) {
     id.delete();
 }
 
+/// An `Enclave<T>` holding `pk`, without an attestation. For unit tests of code
+/// that consumes a registered enclave, which otherwise needs a live enclave to
+/// obtain one. Destroy it with `destroy`.
+#[test_only]
+public fun new_enclave_for_testing<T>(pk: vector<u8>, ctx: &mut TxContext): Enclave<T> {
+    Enclave {
+        id: object::new(ctx),
+        pk,
+        config_version: 0,
+        owner: ctx.sender(),
+    }
+}
+
 #[test_only]
 public struct SigningPayload has copy, drop {
     location: String,
@@ -206,4 +219,46 @@ fun test_serde() {
     );
     let bytes = bcs::to_bytes(&signing_payload);
     assert!(bytes == x"0020b1d110960100000d53616e204672616e636973636f0d00000000000000", 0);
+}
+
+#[test_only]
+public struct TestApp has drop {}
+
+// An ed25519 key pair and a signature over the intent message asserted by
+// `test_serde` above, from the fixed private key seed 0x07 repeated 32 times:
+//
+//   printf '302e020100300506032b657004220420%s' $(printf '07%.0s' $(seq 32)) \
+//     | xxd -r -p | openssl pkey -inform DER -out key.pem
+//   printf '0020b1d110960100000d53616e204672616e636973636f0d00000000000000' \
+//     | xxd -r -p | openssl pkeyutl -sign -inkey key.pem -rawin | xxd -p
+#[test_only]
+const TEST_PK: vector<u8> = x"ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c";
+#[test_only]
+const TEST_SIG: vector<u8> =
+    x"fc1583d7db7a7a5d91f475ade340f02e7ec0a09e6f3a4b2786d99bca32bab9ffd6750f48db7b534e00c4d0d49ef0a3c8371c8f411ce80fae2041fe76d5754403";
+
+#[test]
+fun test_verify_signature() {
+    let mut ctx = tx_context::dummy();
+    let enclave = new_enclave_for_testing<TestApp>(TEST_PK, &mut ctx);
+    let payload = SigningPayload {
+        location: b"San Francisco".to_string(),
+        temperature: 13,
+    };
+    let signature = TEST_SIG;
+    assert!(enclave.verify_signature(0, 1744038900000, payload, &signature));
+    enclave.destroy();
+}
+
+#[test]
+fun test_verify_signature_rejects_tampered_payload() {
+    let mut ctx = tx_context::dummy();
+    let enclave = new_enclave_for_testing<TestApp>(TEST_PK, &mut ctx);
+    let payload = SigningPayload {
+        location: b"San Francisco".to_string(),
+        temperature: 14, // the signature covers 13
+    };
+    let signature = TEST_SIG;
+    assert!(!enclave.verify_signature(0, 1744038900000, payload, &signature));
+    enclave.destroy();
 }


### PR DESCRIPTION
## What

The `enclave` package has a test-only `destroy`, but no way to *construct* an `Enclave<T>` in a test. `Enclave` has private fields and is only produced by `register_enclave`, which needs a real Nitro attestation document.

So the thing this module exists to enable — a package that gates an entry function on `enclave.verify_signature(...)` — cannot be unit tested at all. Downstream authors either skip that coverage or vendor the package to poke a constructor into it. This module had no coverage of `verify_signature` either, for the same reason.

`new_enclave_for_testing` fills the gap:

```move
#[test_only]
public fun new_enclave_for_testing<T>(pk: vector<u8>, ctx: &mut TxContext): Enclave<T>
```

It is `#[test_only]`, so it is stripped before publishing and cannot appear in on-chain bytecode.

## Tests

Two, both enabled by the constructor: a valid signature verifies, and a payload tampered with after signing does not. They use a fixed ed25519 vector over the same intent message `test_serde` already pins, so the two tests agree by construction on what is being signed. The command that generated the key and signature is in a comment above it, so it can be regenerated or checked independently.

```
[ PASS    ] enclave::enclave::test_serde
[ PASS    ] enclave::enclave::test_verify_signature
[ PASS    ] enclave::enclave::test_verify_signature_rejects_tampered_payload
```

I used this downstream to test an `attest`-style entry function end to end; it's the one thing I had to patch into a vendored copy of the package, which is why I'm offering it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
