### PR TITLE
Expose config_version and version accessors on the enclave package

### DIFF
--- a/move/enclave/sources/enclave.move
+++ b/move/enclave/sources/enclave.move
@@ -144,6 +144,18 @@ public fun pk<T>(enclave: &Enclave<T>): &vector<u8> {
     &enclave.pk
 }
 
+/// The config version this enclave registered against. Compare with
+/// `EnclaveConfig::version` to tell whether the PCRs have rotated since.
+public fun config_version<T>(enclave: &Enclave<T>): u64 {
+    enclave.config_version
+}
+
+/// Incremented by every `update_pcrs`. An enclave whose `config_version` is
+/// behind this registered against PCRs that are no longer expected.
+public fun version<T>(config: &EnclaveConfig<T>): u64 {
+    config.version
+}
+
 public fun destroy_old_enclave<T>(e: Enclave<T>, config: &EnclaveConfig<T>) {
     assert!(e.config_version < config.version, EInvalidConfigVersion);
     let Enclave { id, .. } = e;


### PR DESCRIPTION
The version counters that drive PCR rotation are private:

- `EnclaveConfig.version` is incremented by `update_pcrs`;
- `Enclave.config_version` records the version an enclave registered against.

`destroy_old_enclave` already compares them internally (`e.config_version < config.version`), but nothing exposes either field, so a **downstream package cannot read them**. That blocks a package from checking, at call time, whether an enclave is still current — for example, rejecting a `verify_signature` result from an enclave whose PCRs have since rotated, rather than relying on someone destroying each stale `Enclave` object.

This adds two additive getters (`Enclave::config_version`, `EnclaveConfig::version`) alongside the existing `pcr0`/`pk` accessors. No behavior change; existing tests pass (`sui move test` → 3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)