### PR TITLE
Revert nsm_api to the git pin, and add an EIF-build CI to catch it

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,44 @@
+name: Enclave image
+
+# rust.yml compiles nautilus-server with a rustup toolchain, but the enclave image
+# is built with the stagex core-rust pinned in the Containerfile -- a *different*
+# compiler. This job builds the actual EIF, so a dependency MSRV bump (or any
+# Containerfile/toolchain change) that the image build cannot satisfy fails here
+# instead of silently at deploy time. It needs no Nitro hardware: the EIF is a
+# plain reproducible `docker build`, and ubuntu-latest is amd64 so the
+# --platform linux/amd64 build is native.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'Containerfile'
+      - 'Makefile'
+      - 'src/**'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/image.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproducible-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The toolchain images plus the built EIF need more than the default free
+      # space, so drop the preinstalled SDKs the build never touches.
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune --all --force
+          df -h /
+
+      - name: Build the enclave image
+        run: make ENCLAVE_APP=weather-example
+
+      - name: Show the measurements
+        run: cat out/nitro.pcrs

--- a/src/nautilus-server/Cargo.lock
+++ b/src/nautilus-server/Cargo.lock
@@ -247,9 +247,8 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-nitro-enclaves-nsm-api"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986ca4c3a91a67cadc5ae92b3dfe9de373c2b432bb2288eed90203343e9f47c4"
+version = "0.4.0"
+source = "git+https://github.com/aws/aws-nitro-enclaves-nsm-api.git/?rev=8ec7eac72bbb2097f1058ee32c13e1ff232f13e8#8ec7eac72bbb2097f1058ee32c13e1ff232f13e8"
 dependencies = [
  "libc",
  "log",
@@ -528,12 +527,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chrono"
@@ -1641,6 +1634,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,14 +1705,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 1.3.2",
  "cfg-if",
- "cfg_aliases",
  "libc",
+ "memoffset",
+ "pin-utils",
 ]
 
 [[package]]

--- a/src/nautilus-server/Cargo.toml
+++ b/src/nautilus-server/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0"
 serde_yaml = "0.9.34"
 tower-http = { version = "0.6.0", features = ["cors"] }
 fastcrypto = { git = "https://github.com/MystenLabs/fastcrypto", rev = "d1fcb853196c3de7888ed8fad74f419b8c8fbe3b", features = ["aes"] }
-nsm_api = { version = "0.5.2", package = "aws-nitro-enclaves-nsm-api" }
+nsm_api = { git = "https://github.com/aws/aws-nitro-enclaves-nsm-api.git/", rev = "8ec7eac72bbb2097f1058ee32c13e1ff232f13e8", package="aws-nitro-enclaves-nsm-api", optional = false }
 bcs = "0.1.6"
 lazy_static = "1.4"
 uuid = { version = "1.0", features = ["v4"] }


### PR DESCRIPTION
#38 switched `aws-nitro-enclaves-nsm-api` from the git pin to crates.io `0.5.2`. `0.5.2` raises the MSRV to **rustc 1.92**, above the stagex `core-rust` the enclave image builds with (**1.88**), so the reproducible EIF build fails to compile `nautilus-server`. Reproduced just now on `main` (`docker build --target build`):

```
error: rustc 1.88.0 is not supported by the following package:
  aws-nitro-enclaves-nsm-api@0.5.2 requires rustc 1.92
...
ERROR: process "/bin/sh -c cargo build --locked ..." did not complete successfully: exit code: 101
```

CI does not catch this because it never builds the EIF — it compiles with a rustup toolchain (`rust-toolchain.toml`, 1.96), a **different** compiler than the stagex one baked into the image.

Bumping stagex to a release with rustc ≥ 1.92 is not a fix either: the newer stagex kernel/init **does not boot** under the Nitro hypervisor (the enclave panics before init — verified on hardware while building the source-verification service on this base). So this reverts `nsm_api` to the git pin until it ships a release compatible with a bootable toolchain. The tokio and rust-toolchain bumps from #38 are unaffected.

Longer term, an EIF-build CI job (which the source-verification service adds) would catch this class of break before merge.

---

**This PR also adds an EIF-build CI job** (`image.yml`) that catches exactly this class of break before merge. `rust.yml` compiles `nautilus-server` with a rustup toolchain (`rust-toolchain.toml`), but the enclave image is built with the stagex `core-rust` pinned in the `Containerfile` — a *different* compiler. So a dependency MSRV bump above the stagex rustc passes CI while the reproducible EIF build fails. The new job builds the actual EIF (`make ENCLAVE_APP=weather-example`) — no Nitro hardware needed, it's a plain `docker build` — so the mismatch fails CI instead of only surfacing at deploy time.
